### PR TITLE
A few fixes for non-slim builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           # Require --nativecomp and --with-* flags, else the deps will not be included properly
           command: |
             .\emacs-build.cmd --branch ${{ env.EMACS_BRANCH }} --nativecomp --slim --without-pop --without-imagemagick --without-compress-install --without-dbus --with-gnutls --with-json --with-tree-sitter --without-gconf --with-rsvg --without-gsettings --with-mailutils --with-modules  --with-xml2 --with-wide-int --build
-          attempt_limit: 5
+          attempt_limit: 3
           attempt_delay: 2000
 
       - name: Package Emacs

--- a/emacs-build.sh
+++ b/emacs-build.sh
@@ -230,7 +230,6 @@ function action2_install ()
         # we have to copy it by hand.
         make -j $emacs_build_threads -C $emacs_build_dir install \
             && cp "${mingw_dir}bin/libgmp"*.dll "$emacs_install_dir/bin/" \
-            && rm -f "$emacs_install_dir/bin/emacs-"*.exe \
             && emacs_build_strip_exes "$emacs_install_dir" \
             && cp "$emacs_build_root/scripts/site-start.el" "$emacs_install_dir/share/emacs/site-lisp" \
             && mkdir -p "$emacs_install_dir/usr/share/emacs/site-lisp/" \

--- a/emacs-build.sh
+++ b/emacs-build.sh
@@ -306,7 +306,7 @@ function action5_package_all ()
         done
         emacs_build_strip_exes "$emacs_full_install_dir"
         if test "$emacs_compress_files" = "no"; then
-            xargs zip -9v "$emacs_distfile" ./*
+            zip -9rv "$emacs_distfile" ./*
         else
             # find . -type f | sort | dependency_filter > a.txt
             find . -type f | sort | dependency_filter "$packing_slim_exclusion" \

--- a/emacs-build.sh
+++ b/emacs-build.sh
@@ -136,7 +136,8 @@ function emacs_dependencies ()
 function emacs_configure_build_dir ()
 {
     cd "$emacs_build_dir"
-    options="--disable-build-details --without-dbus"
+    # Don't use "--disable-build-details" or else M-x emacs-version won't have build date.
+    options="--without-dbus"
     if test "$emacs_compress_files" = "no"; then
         options="$options --without-compress-install"
     else


### PR DESCRIPTION
I like to make a complete full build with everything enabled on Windows. These fixes make that work.
I also re-enable "build details" since I like M-x emacs-version to have the build date.